### PR TITLE
feat: fix relative on multi-root workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ For optimal performance and to align with project conventions, consider adding t
 
   // 5. Working directory for CLI commands (monorepo)
   "angular.terminal.cwd": "packages/my-angular-app", // adjust to your structure
+  "angular.useRootWorkspace": false, // Use the root workspace folder as the current working directory to resolve relative paths
 
   // 6. Custom CLI commands
   "angular.submenu.customCommands": [
@@ -412,6 +413,7 @@ For optimal performance and to align with project conventions, consider adding t
 | `angular.files.watch`                          | Folders (by type) to watch in the sidebar (`modules`, `components`, `services`) | `["modules","components","services"]` |
 | `angular.files.showPath`                       | Show file paths in the sidebar                                                  | `true`                                |
 | `angular.terminal.cwd`                         | Absolute path for terminal current working directory                            | `(none)`                              |
+| `angular.useRootWorkspace`                     | Allow using the root workspace folder to resolve relative paths                 | `(none)`                              |
 | `angular.submenu.customCommands`               | List of custom CLI commands to show under a submenu                             | `[]`                                  |
 | `angular.submenu.templates`                    | List of custom file templates for quick generation                              | `[]`                                  |
 | `angular.submenu.activateItem`                 | Items (by category) to activate in the submenu                                  | `{ see example }`                     |

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-angular-generator",
   "displayName": "Angular File Generator",
   "description": "The fastest way to generate Angular files from your editor. Integrates the Angular CLI into the VSCode UI to scaffold components, services, and modules with a simple right-click.",
-  "version": "2.17.0",
+  "version": "2.17.2",
   "icon": "icon.png",
   "license": "MIT",
   "publisher": "imgildev",
@@ -131,6 +131,12 @@
           "type": "string",
           "scope": "resource",
           "description": "%angular.terminal.cwd%"
+        },
+        "angular.useRootWorkspace": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource",
+          "description": "%angular.useRootWorkspace%"
         },
         "angular.submenu.customCommands": {
           "type": "array",

--- a/package.nls.json
+++ b/package.nls.json
@@ -7,6 +7,7 @@
   "angular.files.watch": "The list of types of files to watch in the Sidebar Angular File Generator. The default is module, component, directive, enum, guard, interceptor, interface, pipe, resolver, service, and spec.",
   "angular.files.showPath": "Show the path in the list of files in the Sidebar Angular File Generator",
   "angular.terminal.cwd": "Sets the current working directory for the terminal. The directory must be absolute",
+  "angular.useRootWorkspace": "Use the root workspace folder as the current working directory to resolve relative paths.",
   "angular.submenu.customCommands": "The list of custom commands to execute in the Generated Custom Element with CLI submenu",
   "angular.submenu.customCommands.name": "The name of the command",
   "angular.submenu.customCommands.command": "The command to execute",

--- a/src/app/configs/config.ts
+++ b/src/app/configs/config.ts
@@ -121,6 +121,18 @@ export class Config {
    * console.log(config.cwd);
    */
   cwd: string | undefined;
+
+  /**
+   * Use root workspace to resolve relative paths.
+   * @type {string | undefined}
+   * @public
+   * @memberof Config
+   * @example
+   * const config = new Config(workspace.getConfiguration());
+   * console.log(config.useRootWorkspace);
+   */
+  useRootWorkspace: boolean;
+
   /**
    * The custom commands.
    * @type {object[]}
@@ -134,6 +146,7 @@ export class Config {
    * console.log(config.customCommands[0].args);
    */
   customCommands: object[];
+
   /**
    * The custom templates.
    * @type {object[]}
@@ -148,6 +161,7 @@ export class Config {
    * console.log(config.customTemplates[0].template);
    */
   templates: object[];
+
   /**
    * Whether to show the menu or not.
    * @type {MenuInterface}
@@ -159,6 +173,7 @@ export class Config {
    * console.log(config.activateItem.terminal.components);
    */
   activateItem: MenuInterface;
+
   /**
    * Whether to skip the folder confirmation or not.
    * @type {boolean}
@@ -216,6 +231,7 @@ export class Config {
       'terminal.cwd',
       workspace.workspaceFolders?.[0].uri.fsPath,
     );
+    this.useRootWorkspace = config.get<boolean>('useRootWorkspace', false);
     this.customCommands = config.get<object[]>(
       'submenu.customCommands',
       CUSTOM_COMMANDS,
@@ -270,6 +286,10 @@ export class Config {
     this.watch = config.get<string[]>('files.watch', this.watch);
     this.showPath = config.get<boolean>('files.showPath', this.showPath);
     this.cwd = config.get<string | undefined>('terminal.cwd', this.cwd);
+    this.useRootWorkspace = config.get<boolean>(
+      'useRootWorkspace',
+      this.useRootWorkspace,
+    );
     this.customCommands = config.get<object[]>(
       'submenu.customCommands',
       this.customCommands,

--- a/src/app/controllers/file.controller.ts
+++ b/src/app/controllers/file.controller.ts
@@ -1,5 +1,5 @@
 import { statSync } from 'fs';
-import { resolve } from 'path';
+import { relative, resolve } from 'path';
 import { l10n, Uri, window, workspace } from 'vscode';
 
 // Import the Config and helper functions
@@ -42,6 +42,38 @@ export class FileController {
    */
   constructor(private readonly config: Config) {}
 
+  /**
+   * Generates a relative path from the workspace root to the specified path.
+   * If the given path is a file, it will be resolved to the parent folder.
+   * If showPath is disabled, it will return the relative path from the workspace root using
+   * {@linkcode Workspace.asRelativePath}.
+   * @param {Uri} [path] - The path to generate the relative path from.
+   * @returns {string} The relative path.
+   * @memberof FileController
+   */
+  relativePath(path?: Uri): string {
+    // Check if the path is a file
+    if (path && statSync(path.fsPath).isFile()) {
+      path = Uri.file(resolve(path.fsPath, '..'));
+    }
+
+    let folderPath: string = '';
+
+    if (this.config.useRootWorkspace) {
+      // First workspace is the root => https://code.visualstudio.com/api/references/vscode-api#workspace
+      const wsFolder = workspace.workspaceFolders
+        ? workspace.workspaceFolders[0]
+        : '';
+      if (wsFolder && path) {
+        folderPath = relative(wsFolder.uri.fsPath, path.fsPath);
+      }
+    } else {
+      folderPath = path ? workspace.asRelativePath(path.fsPath, false) : '';
+    }
+
+    return folderPath;
+  }
+
   // -----------------------------------------------------------------
   // Methods
   // -----------------------------------------------------------------
@@ -53,13 +85,8 @@ export class FileController {
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateClass(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -124,13 +151,8 @@ export class FileController {
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateComponent(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -205,13 +227,8 @@ export class ${className}${omitSuffix ? '' : 'Component'} {}
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateDirective(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -268,13 +285,8 @@ export class ${className}${omitSuffix ? '' : 'Directive'} {}
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateEnum(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -325,13 +337,8 @@ export class ${className}${omitSuffix ? '' : 'Directive'} {}
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateGuard(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -417,13 +424,8 @@ export const ${entityName}Guard: ${guardType}Fn = (${params}) => {
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateInterceptor(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -490,13 +492,8 @@ export class ${className}Interceptor implements HttpInterceptor {
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateInterface(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -561,13 +558,8 @@ export class ${className}Interceptor implements HttpInterceptor {
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateModule(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -624,13 +616,8 @@ export class ${className}Module {}
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generatePipe(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -689,13 +676,8 @@ export class ${className}Pipe implements PipeTransform {
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateResolver(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -764,13 +746,8 @@ export class ${className}Resolver implements Resolve<boolean> {
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateService(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -827,13 +804,8 @@ export class ${className}${omitSuffix ? '' : 'Service'} {}
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateTest(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     const skipFolderConfirmation = this.config.skipFolderConfirmation;
     let folder: string | undefined;
@@ -947,13 +919,8 @@ describe('${className}${titleize(type)}', () => {
    * @returns Promise resolved when the file is created or operation is cancelled.
    */
   async generateCustomElement(path?: Uri): Promise<void> {
-    // Determine target folder
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    const folderPath: string = this.relativePath(path);
 
     let folder: string | undefined;
 

--- a/src/app/controllers/terminal.controller.ts
+++ b/src/app/controllers/terminal.controller.ts
@@ -1,5 +1,5 @@
 import { statSync } from 'fs';
-import { resolve } from 'path';
+import { relative, resolve } from 'path';
 import { l10n, Uri, window, workspace } from 'vscode';
 
 // Import the Config and helper functions
@@ -264,6 +264,38 @@ export class TerminalController {
   }
 
   /**
+   * Generates a relative path from the workspace root to the specified path.
+   * If the given path is a file, it will be resolved to the parent folder.
+   * If showPath is disabled, it will return the relative path from the workspace root using
+   * {@linkcode Workspace.asRelativePath}.
+   * @param {Uri} [path] - The path to generate the relative path from.
+   * @returns {string} The relative path.
+   * @memberof TerminalController
+   */
+  relativePath(path?: Uri): string {
+    // Check if the path is a file
+    if (path && statSync(path.fsPath).isFile()) {
+      path = Uri.file(resolve(path.fsPath, '..'));
+    }
+
+    let folderPath: string = '';
+
+    if (this.config.useRootWorkspace) {
+      // First workspace is the root => https://code.visualstudio.com/api/references/vscode-api#workspace
+      const wsFolder = workspace.workspaceFolders
+        ? workspace.workspaceFolders[0]
+        : '';
+      if (wsFolder && path) {
+        folderPath = relative(wsFolder.uri.fsPath, path.fsPath);
+      }
+    } else {
+      folderPath = path ? workspace.asRelativePath(path.fsPath, false) : '';
+    }
+
+    return folderPath;
+  }
+
+  /**
    * Creates a new application.
    *
    * @function newApp
@@ -448,13 +480,8 @@ export class TerminalController {
    * @returns Promise resolved when the operation completes or is cancelled.
    */
   async generateComponent(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    let folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    let folderPath: string = this.relativePath(path);
 
     if (this.config.cwd) {
       const cwd = workspace.asRelativePath(Uri.file(this.config.cwd).path);
@@ -757,13 +784,8 @@ export class TerminalController {
    * @returns {Promise<void>} - No return value
    */
   async generateGuard(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    let folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    let folderPath: string = this.relativePath(path);
 
     if (this.config.cwd) {
       const cwd = workspace.asRelativePath(Uri.file(this.config.cwd).path);
@@ -1028,13 +1050,8 @@ export class TerminalController {
    * @returns {Promise<void>} - No return value
    */
   async generatePipe(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    let folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    let folderPath: string = this.relativePath(path);
 
     if (this.config.cwd) {
       const cwd = workspace.asRelativePath(Uri.file(this.config.cwd).path);
@@ -1203,13 +1220,8 @@ export class TerminalController {
    * @returns {Promise<void>} - No return value
    */
   async generateService(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    let folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    let folderPath: string = this.relativePath(path);
 
     if (this.config.cwd) {
       const cwd = workspace.asRelativePath(Uri.file(this.config.cwd).path);
@@ -1382,13 +1394,8 @@ export class TerminalController {
    * @returns {Promise<void>} - The result of the operation
    */
   async generateCustomElement(path?: Uri): Promise<void> {
-    // Check if the path is a file
-    if (path && statSync(path.fsPath).isFile()) {
-      path = Uri.file(resolve(path.fsPath, '..'));
-    }
-
     // Get the relative path
-    const folderPath: string = path ? workspace.asRelativePath(path.path) : '';
+    let folderPath: string = this.relativePath(path);
 
     // Confirm or skip folder
     let folder: string | undefined;


### PR DESCRIPTION
As you can see in [microsoft/vscode#68929](https://github.com/microsoft/vscode/issues/68929) and [microsoft/vscode#200359](https://github.com/microsoft/vscode/issues/200359), the asRelativePath method is not very clear in its documentation, and its purpose is not to provide a valid path but rather a URI. Because of this, in some cases the path generated by the angular-generator extension becomes invalid, especially when using multi-root workspaces.

I ran some tests and was able to get good results with the changes in this PR.

I realize I should have opened a discussion beforehand, but I was in a bit of a rush to solve the issue locally.

If this is of interest to you, or if any adjustments are needed, I’m happy to help.

API Doc: https://code.visualstudio.com/api/references/vscode-api#workspace